### PR TITLE
Add getenv, setenv, with-cwd and with-env

### DIFF
--- a/lish.asd
+++ b/lish.asd
@@ -32,5 +32,6 @@
      (:file "piping"	:depends-on ("package" "vars" "args" "commands"
 				     "shell" "lish"))
      (:file "mine"      :depends-on ("package" "vars" "args" "commands"
-				     "shell" "lish" "piping")))
+                                     "shell" "lish" "piping"))
+     (:file "user-utils" :depends-on ("package")))
     :in-order-to ((asdf:test-op (asdf:test-op :lish-test))))

--- a/package.lisp
+++ b/package.lisp
@@ -97,6 +97,11 @@ it's shell features.
    #:!and #:!or #:!bg
    #:!> #:!>> #:!>! #:!>>!
    #:!< #:!!<
+   ;; user-utils
+   #:getenv
+   #:setenv
+   #:with-cwd
+   #:with-env
    ;; internal-ish things that might want to be used
    #:get-command
    #:command-to-lisp-args

--- a/user-utils.lisp
+++ b/user-utils.lisp
@@ -1,0 +1,78 @@
+
+(in-package :lish)
+
+(defun getenv (name)
+  "Get the environment variable NAME"
+  (nos:environment-variable name))
+
+(defun setenv (name value)
+  "Set environment variable NAME to VALUE.
+If VALUE is NIL then the environment variable NAME is removed.
+If VALUE is non-NIL, princ-to-string is usedd to convert VALUE to a string."
+  (if value
+      (setf (nos:environment-variable name) (princ-to-string value))
+      (setf (nos:environment-variable name) nil)))
+
+(defmacro with-cwd (directory &body body)
+  "Changes the current working directory to DIRECTORY,
+and evaluates BODY. Uses unwind-protect to ensure that
+the previous working directory is restored on exit
+
+Example:
+
+  (with-cwd \"/var/log\"
+    (! \"ls\"))
+"
+  (let ((old-directory (gensym)))
+    `(let ((,old-directory (nos:current-directory)))
+       (unwind-protect
+            (progn
+              (nos:change-directory ,directory)
+              (setf (nos:environment-variable "PWD") (nos:current-directory))
+              ,@body)
+         (nos:change-directory ,old-directory)
+         (setf (nos:environment-variable "PWD") (nos:current-directory))))))
+
+(defmacro with-env (bindings &body body)
+  "Evaluates BODY inside an unwind-protected progn, setting environment variables
+in BINDINGS and restoring the environment afterwards.
+
+BINDINGS should be a list of lists, similar to LET
+
+Example:
+
+  (with-env ((\"TERM\" \"xterm\")
+             (\"PATH\" \"/bin/\"))
+    (! \"echo $TERM\"))
+
+"
+  ;; Check that BINDINGS has the expected structure
+  (unless (listp bindings) (error "BINDINGS must be a list of lists of the form ((env1 value1) (env2 value2))"))
+
+  (dolist (binding bindings)
+    (unless (listp binding) (error "BINDINGS must contain lists (not ~a)" binding))
+    (unless (= 2 (length binding))
+      (error "BINDINGS must contain lists of length 2 (env value)")))
+  
+  ;; Generate symbols to bind to old environment values
+  (let ((old-bindings (loop for i below (length bindings) collect (gensym))))
+    
+    ;; Save current bindings so they can be restored
+    `(let ,(loop
+              for binding in bindings
+              for old-binding in old-bindings
+              collect `(,old-binding (nos:environment-variable ,(first binding))))
+       (unwind-protect
+            (progn
+              ;; Set new environment
+              ,@(loop for binding in bindings
+                   collect `(setf (nos:environment-variable ,(first binding)) ,(second binding)))
+              ,@body)
+         ;; Restore environment
+         ,@(loop
+              for binding in bindings
+              for old-binding in old-bindings
+              collect `(setf (nos:environment-variable ,(first binding)) ,old-binding))))))
+
+
+                  


### PR DESCRIPTION
API from SCSH, useful for manipulating environment in shell scripts. Feel free to ignore if you don't think they're useful. 

getenv and setenv are simple wrappers around nos:environment-variable and are of dubious benefit 

with-cwd and with-env are macros which create an unwind-protected progn, modifying and then restoring the environment. I think these might be quite useful in scripts. 
